### PR TITLE
fix: auto version matching needed to be updated whe auto was updated

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           ## We use `auto version` to calculate whether this is a release build or not
           VERSION_RESULT=$(npx auto version)
           echo "Version calculation result: ${VERSION_RESULT}"
-          if [[ "${VERSION_RESULT}" =~ ^(premajor|preminor|prepatch)$ ]]; then
+          if [[ "${VERSION_RESULT}" =~ (major|minor|patch|release)$ ]]; then
             echo "Release: true"
             echo "release=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- Tests for the changes have been added: n/a
- Docs have been added / updated: n/a
- Does this PR introduce a breaking change? N
- I have linked any related GitHub issues to be closed when this PR is merged? n/a

## Describe the new behavior?
The latest version of `auto` uses different version matching than it previously did. This change brings it inline.
